### PR TITLE
[#12] Endpoint Update and FB Container Handling

### DIFF
--- a/scripts/Meta/figcaption.js
+++ b/scripts/Meta/figcaption.js
@@ -1,4 +1,8 @@
 const figcaption = document.createElement("figcaption");
+export const title = document.createElement("h1");
+export const content = figcaption.appendChild(document.createElement("p"));
+export const footer = document.createElement("footer");
+export const time = footer.appendChild(document.createElement("time"));
 
 export const figcaptionStyle = `
   figcaption {
@@ -37,5 +41,27 @@ export const figcaptionStyle = `
     text-align: right;
   }
 `;
+
+export const dateFormat = {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric"
+};
+
+export const timeFormat = {
+  hour: "2-digit",
+  minute: "2-digit"
+};
+
+export const localizedDateFormat = Object.assign(
+  { timeZone: "America/Los_Angeles" },
+  dateFormat
+);
+
+export const localizedTimeFormat = Object.assign(
+  { timeZone: "America/Los_Angeles" },
+  timeFormat
+);
 
 export default figcaption;

--- a/scripts/Meta/img.js
+++ b/scripts/Meta/img.js
@@ -3,6 +3,7 @@ const img = document.createElement("img");
 export const imgStyle = `
   img {
     width: 100%;
+    text-align: center;
     -webkit-clip-path: polygon(
       5% 0, 0 5%, 0 95%, 5% 100%, 95% 100%, 100% 95%, 100% 5%, 95% 0
     );

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -8,7 +8,7 @@ import figcaption from "./figcaption.js";
 const section = document.querySelector("section");
 const shadowRoot = section.attachShadow({ mode: "open" });
 
-const buildMeta = () => {
+const scaffold = payload => {
   shadowRoot.appendChild(style);
   shadowRoot.appendChild(background);
   shadowRoot.appendChild(figure);
@@ -16,8 +16,16 @@ const buildMeta = () => {
   imgContainer.appendChild(img);
   figure.appendChild(figcaption);
 
+  img.src = payload.image;
+
   return new Promise((resolve, reject) => {
-    img.naturalWidth > 0 ? resolve() : reject("Error: Unable to render image.");
+    img.onload = () => {
+      resolve(payload);
+    };
+
+    img.onerror = () => {
+      reject("⛔️ Error: Unable to load or display image.");
+    };
   });
 };
 
@@ -29,7 +37,6 @@ const handleSuccess = payload => {
 
   background.style.setProperty("--background-image", `url(${payload.image})`);
 
-  img.setAttribute("src", payload.image);
   img.setAttribute("alt", payload.accessibility_caption);
 
   figcaption.innerHTML = `<h1>Instagram</h1>
@@ -82,8 +89,8 @@ const handleError = error => {
 };
 
 const Meta = payload => {
-  handleSuccess(payload)
-    .then(() => buildMeta())
+  scaffold(payload)
+    .then(() => handleSuccess(payload))
     .catch(error => handleError(error));
 };
 

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -15,6 +15,10 @@ const buildMeta = () => {
   figure.appendChild(imgContainer);
   imgContainer.appendChild(img);
   figure.appendChild(figcaption);
+
+  return new Promise((resolve, reject) => {
+    img.naturalWidth > 0 ? resolve() : reject("Error: Unable to render image.");
+  });
 };
 
 const handleSuccess = payload => {
@@ -53,7 +57,9 @@ const handleSuccess = payload => {
 };
 
 const Meta = payload => {
-  handleSuccess(payload).then(() => buildMeta());
+  handleSuccess(payload)
+    .then(() => buildMeta())
+    .catch(error => console.error(error));
 };
 
 export default Meta;

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -64,7 +64,7 @@ const handleError = error => {
     'This error may occur if you have the\
   <a href="https://addons.mozilla.org/en-US/firefox/addon/facebook-container/">\
   Mozilla Facebook Container Extension</a> enabled. The extension\
-  prevents loading images from Instagram if this site is not allowed in\
+  prevents images loading from Instagram if this site is not allowed in\
   Facebook Container.';
   figcaption.innerHTML = `<h1>${error}</h1>
   <p>${isFirefox && noImage && fbContainerMessage}</p>

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -67,7 +67,7 @@ const handleError = error => {
   prevents images loading from Instagram if this site is not allowed in\
   Facebook Container.';
   figcaption.innerHTML = `<h1>${error}</h1>
-  <p>${isFirefox && noImage && fbContainerMessage}</p>
+  <p>${isFirefox && noImage ? fbContainerMessage : ""}</p>
   <footer>
     <time datetime="${date.toISOString()}">${date.toLocaleDateString("en-US", {
     weekday: "long",

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -3,7 +3,16 @@ import background, { context } from "./background.js";
 import figure from "./figure.js";
 import imgContainer from "./imgContainer.js";
 import img from "./img.js";
-import figcaption from "./figcaption.js";
+import figcaption, {
+  content,
+  dateFormat,
+  footer,
+  localizedDateFormat,
+  localizedTimeFormat,
+  time,
+  timeFormat,
+  title
+} from "./figcaption.js";
 
 const section = document.querySelector("section");
 const shadowRoot = section.attachShadow({ mode: "open" });
@@ -15,6 +24,10 @@ const scaffold = payload => {
   figure.appendChild(imgContainer);
   imgContainer.appendChild(img);
   figure.appendChild(figcaption);
+  figcaption.appendChild(title);
+  figcaption.appendChild(content);
+  figcaption.appendChild(footer);
+  footer.appendChild(time);
 
   return new Promise((resolve, reject) => {
     img.src = payload.image;
@@ -35,26 +48,15 @@ const handleSuccess = payload => {
     context.drawImage(bg, 0, 0, background.width, background.height);
   background.style.setProperty("--background-image", `url(${payload.image})`);
 
-  figcaption.innerHTML = `<h1>Instagram</h1>
-  <p>${payload.caption
+  title.textContent = "Instagram";
+  content.innerHTML = `${payload.caption
     .replace(/(\n\n)/g, "</p><p>")
-    .replace(/(\n)/g, "<br />")}</p>
-  <footer>
-    <time datetime="${payload.date.toISOString()}">${payload.date.toLocaleDateString(
+    .replace(/(\n)/g, "<br />")}`;
+  time.setAttribute("datetime", `${payload.date.toISOString()}`);
+  time.textContent = `${payload.date.toLocaleDateString(
     "en-US",
-    {
-      timeZone: "America/Los_Angeles",
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric"
-    }
-  )} at ${payload.date.toLocaleTimeString("en-US", {
-    timeZone: "America/Los_Angeles",
-    hour: "2-digit",
-    minute: "2-digit"
-  })}</time>
-  </footer>`;
+    localizedDateFormat
+  )} at ${payload.date.toLocaleTimeString("en-US", localizedTimeFormat)}`;
 };
 
 const handleError = error => {
@@ -67,19 +69,14 @@ const handleError = error => {
   prevents images loading from Instagram if this site is not allowed in\
   Facebook Container.';
 
-  figcaption.innerHTML = `<h1 style="font-style: normal">${error}</h1>
-  <p>${isFirefox && fbContainerMessage}</p>
-  <footer>
-    <time datetime="${date.toISOString()}">${date.toLocaleDateString("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric"
-  })} at ${date.toLocaleTimeString("en-US", {
-    hour: "2-digit",
-    minute: "2-digit"
-  })}</time>
-  </footer>`;
+  title.setAttribute("style", "font-style: normal");
+  title.textContent = error;
+  content.innerHTML = `${isFirefox && fbContainerMessage}`;
+  time.setAttribute("datetime", `${date.toISOString()}`);
+  time.textContent = `${date.toLocaleDateString(
+    "en-US",
+    dateFormat
+  )} at ${date.toLocaleTimeString("en-US", timeFormat)}`;
 };
 
 const Meta = payload => {

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -66,14 +66,15 @@ const handleSuccess = payload => {
 const handleError = error => {
   const date = new Date();
   const isFirefox = navigator.userAgent.includes("Firefox");
-  const noImage = error === "Error: Unable to render image.";
+  const noImage = error.includes("Unable to load or display image.");
   const fbContainerMessage =
     'This error may occur if you have the\
   <a href="https://addons.mozilla.org/en-US/firefox/addon/facebook-container/">\
   Mozilla Facebook Container Extension</a> enabled. The extension\
   prevents images loading from Instagram if this site is not allowed in\
   Facebook Container.';
-  figcaption.innerHTML = `<h1>${error}</h1>
+
+  figcaption.innerHTML = `<h1 style="font-style: normal">${error}</h1>
   <p>${isFirefox && noImage ? fbContainerMessage : ""}</p>
   <footer>
     <time datetime="${date.toISOString()}">${date.toLocaleDateString("en-US", {

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -16,15 +16,14 @@ const scaffold = payload => {
   imgContainer.appendChild(img);
   figure.appendChild(figcaption);
 
-  img.src = payload.image;
-
   return new Promise((resolve, reject) => {
+    img.src = payload.image;
+    img.setAttribute("alt", payload.accessibility_caption);
     img.onload = () => {
       resolve(payload);
     };
-
     img.onerror = () => {
-      reject("⛔️ Error: Unable to load or display image.");
+      reject("⛔️ Error: Unable to load image.");
     };
   });
 };
@@ -34,10 +33,7 @@ const handleSuccess = payload => {
   bg.src = payload.image;
   bg.onload = () =>
     context.drawImage(bg, 0, 0, background.width, background.height);
-
   background.style.setProperty("--background-image", `url(${payload.image})`);
-
-  img.setAttribute("alt", payload.accessibility_caption);
 
   figcaption.innerHTML = `<h1>Instagram</h1>
   <p>${payload.caption
@@ -59,14 +55,11 @@ const handleSuccess = payload => {
     minute: "2-digit"
   })}</time>
   </footer>`;
-
-  return Promise.resolve();
 };
 
 const handleError = error => {
   const date = new Date();
   const isFirefox = navigator.userAgent.includes("Firefox");
-  const noImage = error.includes("Unable to load or display image.");
   const fbContainerMessage =
     'This error may occur if you have the\
   <a href="https://addons.mozilla.org/en-US/firefox/addon/facebook-container/">\
@@ -75,7 +68,7 @@ const handleError = error => {
   Facebook Container.';
 
   figcaption.innerHTML = `<h1 style="font-style: normal">${error}</h1>
-  <p>${isFirefox && noImage ? fbContainerMessage : ""}</p>
+  <p>${isFirefox && fbContainerMessage}</p>
   <footer>
     <time datetime="${date.toISOString()}">${date.toLocaleDateString("en-US", {
     weekday: "long",

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -56,10 +56,26 @@ const handleSuccess = payload => {
   return Promise.resolve();
 };
 
+const handleError = error => {
+  const date = new Date();
+  figcaption.innerHTML = `<h1>${error}</h1>
+  <footer>
+    <time datetime="${date.toISOString()}">${date.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric"
+  })} at ${date.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit"
+  })}</time>
+  </footer>`;
+};
+
 const Meta = payload => {
   handleSuccess(payload)
     .then(() => buildMeta())
-    .catch(error => console.error(error));
+    .catch(error => handleError(error));
 };
 
 export default Meta;

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -58,7 +58,16 @@ const handleSuccess = payload => {
 
 const handleError = error => {
   const date = new Date();
+  const isFirefox = navigator.userAgent.includes("Firefox");
+  const noImage = error === "Error: Unable to render image.";
+  const fbContainerMessage =
+    'This error may occur if you have the\
+  <a href="https://addons.mozilla.org/en-US/firefox/addon/facebook-container/">\
+  Mozilla Facebook Container Extension</a> enabled. The extension\
+  prevents loading images from Instagram if this site is not allowed in\
+  Facebook Container.';
   figcaption.innerHTML = `<h1>${error}</h1>
+  <p>${isFirefox && noImage && fbContainerMessage}</p>
   <footer>
     <time datetime="${date.toISOString()}">${date.toLocaleDateString("en-US", {
     weekday: "long",

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -15,15 +15,14 @@ const validateResponse = response => {
 
 const normalizeResponse = response => {
   const latestPost =
-    response.graphql.user.edge_owner_to_timeline_media.edges[0].node;
+    response.data[0];
   return {
     accessibility_caption:
       latestPost.accessibility_caption || "Accessibility caption not provided",
     caption:
-      latestPost.edge_media_to_caption.edges[0] &&
-      latestPost.edge_media_to_caption.edges[0].node.text,
-    date: new Date(latestPost.taken_at_timestamp * 1000),
-    image: latestPost.display_url
+      latestPost.caption,
+    date: new Date(latestPost.timestamp),
+    image: latestPost.media_url
   };
 };
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -36,7 +36,9 @@ const handleSupported = () =>
       document.getElementById("message").textContent = `⛔️ ${error}`;
     });
 
-const handleUnsupported = () => console.info("handleUnsupported");
+const handleUnsupported = () =>
+  (document.getElementById("message").textContent =
+    "😞 This browser is unsupported.");
 
 window.addEventListener("load", () => {
   isSupported ? handleSupported() : handleUnsupported();

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,7 +1,7 @@
 import CONTACT_INFO from "./contact.js";
 import isSupported from "./support.js";
 
-const instagramURL = "https://www.instagram.com/zulaica/?__a=1";
+const instagramURL = "http://127.0.0.1:3001/instagram";
 
 const validateResponse = response => {
   if (!response.ok) {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -21,7 +21,7 @@ const normalizeResponse = response => {
       latestPost.accessibility_caption || "Accessibility caption not provided",
     caption:
       latestPost.caption,
-    date: new Date(latestPost.timestamp),
+    date: new Date(latestPost.timestamp.replace(/\+0000/g, "Z")),
     image: latestPost.media_url
   };
 };

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,7 +1,7 @@
 import CONTACT_INFO from "./contact.js";
 import isSupported from "./support.js";
 
-const instagramURL = "http://127.0.0.1:3001/instagram";
+const instagramURL = "https://zulaica.dev/instagram";
 
 const normalizeResponse = response => {
   const latestPost = response.data[0];

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -3,24 +3,12 @@ import isSupported from "./support.js";
 
 const instagramURL = "http://127.0.0.1:3001/instagram";
 
-const validateResponse = response => {
-  if (!response.ok) {
-    throw new Error(
-      `${response.statusText}` || "😞 An unknown error has occurred."
-    );
-  }
-
-  return response.json();
-};
-
 const normalizeResponse = response => {
-  const latestPost =
-    response.data[0];
+  const latestPost = response.data[0];
   return {
     accessibility_caption:
       latestPost.accessibility_caption || "Accessibility caption not provided",
-    caption:
-      latestPost.caption,
+    caption: latestPost.caption,
     date: new Date(latestPost.timestamp.replace(/\+0000/g, "Z")),
     image: latestPost.media_url
   };
@@ -30,12 +18,13 @@ const handleSupported = () =>
   fetch(instagramURL)
     .then(response => {
       if (!response.ok) {
-        throw new Error("⛔️ Something went wrong");
+        throw new Error(
+          `${response.statusText}` || "😞 An unknown error has occurred."
+        );
       }
 
-      return response;
+      return response.json();
     })
-    .then(response => validateResponse(response))
     .then(response => normalizeResponse(response))
     .then(payload => {
       import("./Meta/index.js").then(module => module.default(payload));

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,7 +7,7 @@ const normalizeResponse = response => {
   const latestPost = response.data[0];
   return {
     accessibility_caption:
-      latestPost.accessibility_caption || "Accessibility caption not provided",
+      latestPost.accessibility_caption || "Accessibility caption not provided.",
     caption: latestPost.caption,
     date: new Date(latestPost.timestamp.replace(/\+0000/g, "Z")),
     image: latestPost.media_url

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -34,23 +34,6 @@ const handleSupported = () =>
     })
     .catch(error => {
       document.getElementById("message").textContent = `⛔️ ${error}`;
-      if (
-        error
-          .toString()
-          .includes(
-            "TypeError: NetworkError when attempting to fetch resource."
-          )
-      ) {
-        document.getElementById("context").innerHTML =
-          'This error may occur if you have the\
-          <a href="https://addons.mozilla.org/en-US/firefox/addon/facebook-container/">\
-          Mozilla Facebook Container Extension</a> enabled. The extension\
-          prevents loading the Instagram API from the private/unsupported\
-          endpoint that is currently being used to display my latest post.\
-          It is a known issue and a solution using the\
-          <a href="https://developers.facebook.com/docs/instagram-basic-display-api/reference/media">\
-          Instagram Basic Display API</a> is currently in development.';
-      }
     });
 
 const handleUnsupported = () => console.info("handleUnsupported");


### PR DESCRIPTION
#12 

- Set up usage with proxy
- Update and refactor code to use new payload
- Improve error handling
- Account for users with Mozilla's Facebook Container extension enabled
- Wrap image request in a Promise
- Update error handling and messaging

### Screenshots

#### Mozilla Facebook Container installed, not allowed in container
<img width="1552" alt="Screen Shot 2020-06-03 at 7 39 42 PM" src="https://user-images.githubusercontent.com/4645082/83708853-16a74e80-a5d2-11ea-9b70-525d20e58b49.png">


#### Mozilla Facebook Container installed, allowed in container
<img width="1552" alt="Screen Shot 2020-06-02 at 12 24 05 PM" src="https://user-images.githubusercontent.com/4645082/83562101-d6f73e80-a4cd-11ea-9360-5cff4d5af0f0.png">

