### PR TITLE
[#14] Apply Letterbox to Non-Square Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ JavaScript, and <abbr title="Cascading Style Sheets">CSS</abbr> APIs.
 
 > Aren't you concerned about **LEGACY-BROWSER**?
 
-Nope.
+[Nope](https://github.com/zulaica/zulaica-dot-info/blob/release/scripts/index.js#L39).
 
 > This looks not-very-good on mobile.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ JavaScript, and <abbr title="Cascading Style Sheets">CSS</abbr> APIs.
 - [`prefers-color-scheme` media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
 - [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
 - [`calc()` CSS Function](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
+- [CSS Feature Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports)
 
 > Aren't you concerned about **LEGACY-BROWSER**?
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ JavaScript, and <abbr title="Cascading Style Sheets">CSS</abbr> APIs.
 - [JavaScript Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules)
 - [Dynamic Module Imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports)
 - [CSS Custom Properties (Variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
-- [`prefers-color-scheme` media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+- [`prefers-color-scheme` Media Query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
 - [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
 - [`calc()` CSS Function](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
 - [CSS Feature Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports)

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ JavaScript, and <abbr title="Cascading Style Sheets">CSS</abbr> APIs.
 - [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM)
 - [JavaScript Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules)
 - [Dynamic Module Imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports)
-- [CSS Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
+- [CSS Custom Properties (Variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
 - [`prefers-color-scheme` media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
 - [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
+- [`calc()` CSS Function](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
 
 > Aren't you concerned about **LEGACY-BROWSER**?
 

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
     <script nomodule>
       document.getElementById("message").textContent = "⚠️ Unsupported Browser";
       document.getElementById("context").innerHTML =
-        'This browser does not support the features required to render this\
+        'Your browser does not support the features required to render this\
         site. Please consider <a href="https://browsehappy.com">\
         upgrading to a modern browser</a>.';
     </script>

--- a/scripts/Meta/figcaption.js
+++ b/scripts/Meta/figcaption.js
@@ -19,7 +19,7 @@ export const figcaptionStyle = `
     background: var(--background-color);
     border: 1px solid var(--border-color);
     border-right: transparent;
-    border-radius: 3px;
+    border-radius: 2px;
     box-shadow: var(--shade);
   }
 

--- a/scripts/Meta/figcaption.js
+++ b/scripts/Meta/figcaption.js
@@ -9,7 +9,9 @@ export const figcaptionStyle = `
     width: 45vw;
     height: max-content;
     margin: auto 0;
+    margin-right: -2px;
     padding: 2.5rem;
+    padding-right: calc(2.5rem + 2px);
     text-align: left;
     font-size: 1.125rem;
     line-height: 1.5;

--- a/scripts/Meta/figcaption.js
+++ b/scripts/Meta/figcaption.js
@@ -9,9 +9,9 @@ export const figcaptionStyle = `
     width: 45vw;
     height: max-content;
     margin: auto 0;
-    margin-right: -2px;
-    padding: 2.5rem;
-    padding-right: calc(2.5rem + 2px);
+    margin-right: calc(-1 * var(--border-radius));
+    padding: var(--caption-padding);
+    padding-right: calc(var(--caption-padding) + var(--border-radius));
     text-align: left;
     font-size: 1.125rem;
     line-height: 1.5;

--- a/scripts/Meta/figcaption.js
+++ b/scripts/Meta/figcaption.js
@@ -19,7 +19,7 @@ export const figcaptionStyle = `
     background: var(--background-color);
     border: 1px solid var(--border-color);
     border-right: transparent;
-    border-radius: 2px;
+    border-radius: var(--border-radius);
     box-shadow: var(--shade);
   }
 

--- a/scripts/Meta/figcaption.js
+++ b/scripts/Meta/figcaption.js
@@ -14,7 +14,6 @@ export const figcaptionStyle = `
     padding-right: calc(var(--caption-padding) + var(--border-radius));
     text-align: left;
     font-size: 1.125rem;
-    line-height: 1.5;
     color: var(--text-color);
     background: var(--background-color);
     border: 1px solid var(--border-color);

--- a/scripts/Meta/img.js
+++ b/scripts/Meta/img.js
@@ -4,6 +4,7 @@ export const imgStyle = `
   img {
     width: 100%;
     text-align: center;
+    border-radius: 2px;
   }
 `;
 

--- a/scripts/Meta/img.js
+++ b/scripts/Meta/img.js
@@ -4,12 +4,6 @@ export const imgStyle = `
   img {
     width: 100%;
     text-align: center;
-    -webkit-clip-path: polygon(
-      5% 0, 0 5%, 0 95%, 5% 100%, 95% 100%, 100% 95%, 100% 5%, 95% 0
-    );
-    clip-path: polygon(
-      5% 0, 0 5%, 0 95%, 5% 100%, 95% 100%, 100% 95%, 100% 5%, 95% 0
-    );
   }
 `;
 

--- a/scripts/Meta/img.js
+++ b/scripts/Meta/img.js
@@ -4,7 +4,7 @@ export const imgStyle = `
   img {
     width: 100%;
     text-align: center;
-    border-radius: 2px;
+    border-radius: var(--border-radius);
   }
 `;
 

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -10,7 +10,7 @@ export const imgContainerStyle = `
     margin: auto;
     background: var(--image-container-color);
     border: 1px solid var(--image-container-color);
-    border-radius: 3px;
+    border-radius: 2px;
     box-shadow: var(--shade);
   }
 

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -14,15 +14,16 @@ export const imgContainerStyle = `
     box-shadow: var(--shade);
   }
 
-  div::after {
-    content: "";
-    position: absolute;
-    width: var(--image-size);
-    height: var(--image-size);
-    border-radius: var(--border-radius);
-    background: var(--photo-corner-color);
-    -webkit-clip-path: polygon(var(--clip-path));
-    clip-path: polygon(var(--clip-path));
+  @supports (clip-path: polygon(0% 0%)){
+    div::after {
+      content: "";
+      position: absolute;
+      width: var(--image-size);
+      height: var(--image-size);
+      border-radius: var(--border-radius);
+      background: var(--photo-corner-color);
+      clip-path: polygon(var(--clip-path));
+    }
   }
 `;
 

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -17,8 +17,8 @@ export const imgContainerStyle = `
   div::after {
     content: "";
     position: absolute;
-    width: 33vw;
-    height: 33vw;
+    width: var(--image-size);
+    height: var(--image-size);
     border-radius: 2px;
     background: var(--photo-corner-color);
     -webkit-clip-path: polygon(var(--clip-path));

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -21,12 +21,8 @@ export const imgContainerStyle = `
     height: 33vw;
     border-radius: 2px;
     background: #fff;
-    -webkit-clip-path: polygon(
-      0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%, 5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%, 95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%
-    );
-    clip-path: polygon(
-      0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%, 5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%, 95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%
-    );
+    -webkit-clip-path: polygon(var(--clip-path));
+    clip-path: polygon(var(--clip-path));
   }
 `;
 

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -13,6 +13,21 @@ export const imgContainerStyle = `
     border-radius: 3px;
     box-shadow: var(--shade);
   }
+
+  div::after {
+    content: "";
+    position: absolute;
+    width: 33vw;
+    height: 33vw;
+    border-radius: 2px;
+    background: #fff;
+    -webkit-clip-path: polygon(
+      0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%, 5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%, 95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%
+    );
+    clip-path: polygon(
+      0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%, 5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%, 95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%
+    );
+  }
 `;
 
 export default imgContainer;

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -5,8 +5,8 @@ export const imgContainerStyle = `
     display: flex;
     align-items: center;
     justify-items: center;
-    width: 33vw;
-    height: 33vw;
+    width: var(--image-size);
+    height: var(--image-size);
     margin: auto;
     background: var(--image-container-color);
     border: 1px solid var(--image-container-color);

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -20,7 +20,7 @@ export const imgContainerStyle = `
     width: 33vw;
     height: 33vw;
     border-radius: 2px;
-    background: #fff;
+    background: var(--photo-corner-color);
     -webkit-clip-path: polygon(var(--clip-path));
     clip-path: polygon(var(--clip-path));
   }

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -10,7 +10,7 @@ export const imgContainerStyle = `
     margin: auto;
     background: var(--image-container-color);
     border: 1px solid var(--image-container-color);
-    border-radius: 2px;
+    border-radius: var(--border-radius);
     box-shadow: var(--shade);
   }
 
@@ -19,7 +19,7 @@ export const imgContainerStyle = `
     position: absolute;
     width: var(--image-size);
     height: var(--image-size);
-    border-radius: 2px;
+    border-radius: var(--border-radius);
     background: var(--photo-corner-color);
     -webkit-clip-path: polygon(var(--clip-path));
     clip-path: polygon(var(--clip-path));

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -8,8 +8,8 @@ export const imgContainerStyle = `
     width: 33vw;
     height: 33vw;
     margin: auto;
-    background: var(--img-container-color);
-    border: 1px solid var(--img-container-color);
+    background: var(--image-container-color);
+    border: 1px solid var(--image-container-color);
     border-radius: 3px;
     box-shadow: var(--shade);
   }

--- a/scripts/Meta/imgContainer.js
+++ b/scripts/Meta/imgContainer.js
@@ -6,6 +6,7 @@ export const imgContainerStyle = `
     align-items: center;
     justify-items: center;
     width: 33vw;
+    height: 33vw;
     margin: auto;
     background: var(--img-container-color);
     border: 1px solid var(--img-container-color);

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -36,9 +36,13 @@ const handleSupported = () =>
       document.getElementById("message").textContent = `⛔️ ${error}`;
     });
 
-const handleUnsupported = () =>
-  (document.getElementById("message").textContent =
-    "😞 This browser is unsupported.");
+const handleUnsupported = () => {
+  document.getElementById("message").textContent = "⚠️ Unsupported Browser";
+  document.getElementById("context").innerHTML =
+    'Your browser does not support the features required to render this\
+    site. Please consider <a href="https://browsehappy.com"> upgrading to a\
+    modern browser</a>.';
+};
 
 window.addEventListener("load", () => {
   isSupported ? handleSupported() : handleUnsupported();

--- a/styles/404.css
+++ b/styles/404.css
@@ -15,7 +15,7 @@ html {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   font-size: 16px;
-  line-height: 1.5em;
+  line-height: 1.5;
   vertical-align: baseline;
   text-rendering: optimizeLegibility;
   font-variant-ligatures: common-ligatures discretionary-ligatures;
@@ -101,7 +101,7 @@ body {
 }
 
 pre {
-  line-height: 1.25em;
+  line-height: 1.25;
   font-family: monospace;
 }
 

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -28,6 +28,7 @@
 }
 
 :root {
+  --border-radius: 2px;
   --clip-path: 0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%,
     5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%,
     95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%;

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -51,7 +51,7 @@ html {
   -webkit-text-size-adjust: 100%;
 
   font-size: 16px;
-  line-height: 1.5em;
+  line-height: 1.5;
   vertical-align: baseline;
 
   text-rendering: geometricPrecision;
@@ -160,7 +160,6 @@ section #message {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.35rem;
-  line-height: 1.5;
 }
 
 section #context {

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -29,6 +29,7 @@
 
 :root {
   --border-radius: 2px;
+  --caption-padding: 2.5rem;
   --clip-path: 0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%,
     5% 1px, 95% 1px, calc(var(--image-size) - 1px) 5%,
     calc(var(--image-size) - 1px) 95%, 95% calc(var(--image-size) - 1px),

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -32,6 +32,7 @@
     5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%,
     95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%;
   --image-container-color: #000;
+  --image-size: 33vw;
   --photo-corner-color: #fff;
   --shade: 0 0 0 2px var(--shade-color);
 }

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -28,7 +28,7 @@
 }
 
 :root {
-  --img-container-color: #aaa3;
+  --img-container-color: #000;
   --shade: 0 0 0 2px var(--shade-color);
 }
 

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -28,6 +28,9 @@
 }
 
 :root {
+  --clip-path: 0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%,
+    5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%,
+    95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%;
   --img-container-color: #000;
   --shade: 0 0 0 2px var(--shade-color);
 }

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -31,7 +31,7 @@
   --clip-path: 0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%,
     5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%,
     95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%;
-  --img-container-color: #000;
+  --image-container-color: #000;
   --photo-corner-color: #fff;
   --shade: 0 0 0 2px var(--shade-color);
 }

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -32,6 +32,7 @@
     5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%,
     95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%;
   --img-container-color: #000;
+  --photo-corner-color: #fff;
   --shade: 0 0 0 2px var(--shade-color);
 }
 

--- a/styles/meta.css
+++ b/styles/meta.css
@@ -30,8 +30,9 @@
 :root {
   --border-radius: 2px;
   --clip-path: 0px 0px, 0px 100%, 100% 100%, 100% 0px, 0px 0px, 2.5% 2.5%,
-    5% 1px, 95% 1px, calc(33vw - 1px) 5%, calc(33vw - 1px) 95%,
-    95% calc(33vw - 1px), 5% calc(33vw - 1px), 1px 95%, 1px 5%, 2.5% 2.5%;
+    5% 1px, 95% 1px, calc(var(--image-size) - 1px) 5%,
+    calc(var(--image-size) - 1px) 95%, 95% calc(var(--image-size) - 1px),
+    5% calc(var(--image-size) - 1px), 1px 95%, 1px 5%, 2.5% 2.5%;
   --image-container-color: #000;
   --image-size: 33vw;
   --photo-corner-color: #fff;


### PR DESCRIPTION
Closes #14 

- Non-square images are rendered as letterbox
- Photo corner effect rewritten with pseudo element overlay
- Adjust `figcaption` layout
- Improve CSS variable implementation and usage
- Improve messaging for unsupported browsers
- Cleanup

### Screenshot

<img width="1552" alt="Screen Shot 2020-06-15 at 3 03 45 AM" src="https://user-images.githubusercontent.com/4645082/84645058-e48ccb00-aeb4-11ea-81e4-11d54019c085.png">
