### PR TITLE
[#18] Refactor with `append()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ JavaScript, and <abbr title="Cascading Style Sheets">CSS</abbr> APIs.
 - [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
 - [`calc()` CSS Function](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
 - [CSS Feature Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports)
+- [Default Function Parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
 
 > Aren't you concerned about **LEGACY-BROWSER**?
 

--- a/index.html
+++ b/index.html
@@ -48,8 +48,9 @@
     <script>
       function dynamicImportSupported() {
         try {
-          new Function("import('')");
-          return true;
+          return new Function(
+            "return import('data:text/javascript;base64,Cg==').then(() => true)"
+          );
         } catch (error) {
           switch (error instanceof SyntaxError) {
             case true:

--- a/scripts/Meta/background.js
+++ b/scripts/Meta/background.js
@@ -4,7 +4,7 @@ background.role = "presentation";
 background.ariaHidden = true;
 
 export const context = background.getContext("2d", { alpha: true });
-const canvasBlurSupported = context && context.filter;
+const canvasBlurSupported = !!context.filter;
 
 if (canvasBlurSupported) {
   context.filter = "blur(10px)";

--- a/scripts/Meta/background.js
+++ b/scripts/Meta/background.js
@@ -11,7 +11,6 @@ if (canvasBlurSupported) {
 }
 
 const cssBlur = `
-  background: var(--background-image);
   background-position: center;
   background-size: cover;
   filter: blur(50px);

--- a/scripts/Meta/background.js
+++ b/scripts/Meta/background.js
@@ -1,7 +1,7 @@
 const background = document.createElement("canvas");
-background.setAttribute("id", "background");
-background.setAttribute("role", "presentation");
-background.setAttribute("aria-hidden", "true");
+background.id = "background";
+background.role = "presentation";
+background.ariaHidden = true;
 
 export const context = background.getContext("2d", { alpha: true });
 const canvasBlurSupported = context && context.filter;

--- a/scripts/Meta/figcaption.js
+++ b/scripts/Meta/figcaption.js
@@ -1,8 +1,8 @@
 const figcaption = document.createElement("figcaption");
 export const title = document.createElement("h1");
-export const content = figcaption.appendChild(document.createElement("p"));
+export const content = document.createElement("p");
 export const footer = document.createElement("footer");
-export const time = footer.appendChild(document.createElement("time"));
+export const time = document.createElement("time");
 
 export const figcaptionStyle = `
   figcaption {

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -27,7 +27,7 @@ const scaffold = payload => {
 
   return new Promise((resolve, reject) => {
     img.src = payload.image;
-    img.setAttribute("alt", payload.accessibility_caption);
+    img.alt = payload.accessibility_caption;
     img.onload = () => {
       resolve(payload);
     };
@@ -48,7 +48,7 @@ const handleSuccess = payload => {
   content.innerHTML = `${payload.caption
     .replace(/(\n\n)/g, "</p><p>")
     .replace(/(\n)/g, "<br />")}`;
-  time.setAttribute("datetime", `${payload.date.toISOString()}`);
+  time.dateTime = `${payload.date.toISOString()}`;
   time.textContent = `${payload.date.toLocaleDateString(
     "en-US",
     localizedDateFormat
@@ -65,10 +65,10 @@ const handleError = error => {
   prevents images loading from Instagram if this site is not allowed in\
   Facebook Container.';
 
-  title.setAttribute("style", "font-style: normal");
+  title.style = "font-style: normal";
   title.textContent = error;
   content.innerHTML = `${isFirefox && fbContainerMessage}`;
-  time.setAttribute("datetime", `${date.toISOString()}`);
+  time.dateTime = `${date.toISOString()}`;
   time.textContent = `${date.toLocaleDateString(
     "en-US",
     dateFormat

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -44,15 +44,17 @@ const handleSuccess = payload => {
     context.drawImage(bg, 0, 0, background.width, background.height);
   background.style.setProperty("--background-image", `url(${payload.image})`);
 
-  title.textContent = "Instagram";
+  title.append("Instagram");
   content.innerHTML = `${payload.caption
     .replace(/(\n\n)/g, "</p><p>")
     .replace(/(\n)/g, "<br />")}`;
   time.dateTime = `${payload.date.toISOString()}`;
-  time.textContent = `${payload.date.toLocaleDateString(
-    "en-US",
-    localizedDateFormat
-  )} at ${payload.date.toLocaleTimeString("en-US", localizedTimeFormat)}`;
+  time.append(
+    `${payload.date.toLocaleDateString(
+      "en-US",
+      localizedDateFormat
+    )} at ${payload.date.toLocaleTimeString("en-US", localizedTimeFormat)}`
+  );
 };
 
 const handleError = error => {
@@ -66,13 +68,15 @@ const handleError = error => {
   Facebook Container.';
 
   title.style = "font-style: normal";
-  title.textContent = error;
+  title.append(error);
   content.innerHTML = `${isFirefox && fbContainerMessage}`;
   time.dateTime = `${date.toISOString()}`;
-  time.textContent = `${date.toLocaleDateString(
-    "en-US",
-    dateFormat
-  )} at ${date.toLocaleTimeString("en-US", timeFormat)}`;
+  time.append(
+    `${date.toLocaleDateString(
+      "en-US",
+      dateFormat
+    )} at ${date.toLocaleTimeString("en-US", timeFormat)}`
+  );
 };
 
 const Meta = payload => {

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -50,7 +50,6 @@ const handleSuccess = payload => {
   bg.src = payload.image;
   bg.onload = () =>
     context.drawImage(bg, 0, 0, background.width, background.height);
-  background.style.setProperty("--background-image", `url(${payload.image})`);
 
   title.append("Instagram");
   content.innerHTML = `${payload.caption

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -18,16 +18,12 @@ const section = document.querySelector("section");
 const shadowRoot = section.attachShadow({ mode: "open" });
 
 const scaffold = payload => {
-  shadowRoot.appendChild(style);
-  shadowRoot.appendChild(background);
-  shadowRoot.appendChild(figure);
-  figure.appendChild(imgContainer);
-  imgContainer.appendChild(img);
-  figure.appendChild(figcaption);
-  figcaption.appendChild(title);
-  figcaption.appendChild(content);
-  figcaption.appendChild(footer);
-  footer.appendChild(time);
+  shadowRoot.append(style, background, figure);
+  figure.append(imgContainer);
+  imgContainer.append(img);
+  figure.append(figcaption);
+  figcaption.append(title, content, footer);
+  footer.append(time);
 
   return new Promise((resolve, reject) => {
     img.src = payload.image;

--- a/scripts/Meta/index.js
+++ b/scripts/Meta/index.js
@@ -16,6 +16,14 @@ import figcaption, {
 
 const section = document.querySelector("section");
 const shadowRoot = section.attachShadow({ mode: "open" });
+const formatDateTime = (dateObject, localized = false) =>
+  `${dateObject.toLocaleDateString(
+    "en-US",
+    localized ? localizedDateFormat : dateFormat
+  )} at ${dateObject.toLocaleTimeString(
+    "en-US",
+    localized ? localizedTimeFormat : timeFormat
+  )}`;
 
 const scaffold = payload => {
   shadowRoot.append(style, background, figure);
@@ -49,12 +57,7 @@ const handleSuccess = payload => {
     .replace(/(\n\n)/g, "</p><p>")
     .replace(/(\n)/g, "<br />")}`;
   time.dateTime = `${payload.date.toISOString()}`;
-  time.append(
-    `${payload.date.toLocaleDateString(
-      "en-US",
-      localizedDateFormat
-    )} at ${payload.date.toLocaleTimeString("en-US", localizedTimeFormat)}`
-  );
+  time.append(formatDateTime(payload.date, true));
 };
 
 const handleError = error => {
@@ -71,12 +74,7 @@ const handleError = error => {
   title.append(error);
   content.innerHTML = `${isFirefox && fbContainerMessage}`;
   time.dateTime = `${date.toISOString()}`;
-  time.append(
-    `${date.toLocaleDateString(
-      "en-US",
-      dateFormat
-    )} at ${date.toLocaleTimeString("en-US", timeFormat)}`
-  );
+  time.append(formatDateTime(date));
 };
 
 const Meta = payload => {

--- a/scripts/Meta/style.js
+++ b/scripts/Meta/style.js
@@ -5,12 +5,12 @@ import { imgStyle } from "./img.js";
 import { figcaptionStyle } from "./figcaption.js";
 
 const style = document.createElement("style");
-style.textContent = `
+style.append(`
   ${backgroundStyle}
   ${figureStyle}
   ${imgContainerStyle}
   ${imgStyle}
   ${figcaptionStyle}
-`;
+`);
 
 export default style;

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -33,15 +33,18 @@ const handleSupported = () =>
       );
     })
     .catch(error => {
-      document.getElementById("message").textContent = `⛔️ ${error}`;
+      document.getElementById("message").append(`⛔️ ${error}`);
     });
 
 const handleUnsupported = () => {
-  document.getElementById("message").textContent = "⚠️ Unsupported Browser";
-  document.getElementById("context").innerHTML =
-    'Your browser does not support the features required to render this\
-    site. Please consider <a href="https://browsehappy.com"> upgrading to a\
-    modern browser</a>.';
+  document.getElementById("message").append("⚠️ Unsupported Browser");
+  document
+    .getElementById("context")
+    .append(
+      'Your browser does not support the features required to render this\
+      site. Please consider <a href="https://browsehappy.com"> upgrading to a\
+      modern browser</a>.'
+    );
 };
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
Closes #18 

- Makes use of `ParentNode.append()` where possible
- Refactors attribute assignment with dot notation
- Reduces code duplication
- Refactors dynamic import detection
- Cleanup